### PR TITLE
Bump yew version to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 repository = "https://github.com/WorldSEnder/yew-virtualized"
 
 [dependencies]
-yew = { version = "0.19" }
+yew = { version = "0.20" }
 web-sys = { version = "0.3", features = ["DomRectReadOnly"] }
 gloo-timers = "0.2"
 wasm-bindgen = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ impl Component for VirtualList {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+    fn changed(&mut self, ctx: &Context<Self>, _props: &<Self as yew::Component>::Properties) -> bool {
         ctx.link().send_message(VirtualListMsg(ScrollMsg::Update));
         // triggered indirectly via Message::Update
         false


### PR DESCRIPTION
Upgrading to yew version 0.20.

Passes `cargo check` and `cargo test`